### PR TITLE
Add interactive Voronoi maze generator UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
-# Voronoi_Maze_Generator
-A simple HTML/JS based Voronoi Maze generator
+# Voronoi Maze Generator
+
+A modern single-page Voronoi maze generator that uses D3's Delaunay/Voronoi utilities to create organic-looking tilings and then carves a perfect maze via Kruskal's algorithm.
+
+## Features
+
+- Adjustable maze structure (cell count, canvas size, Lloyd relaxation, passage width)
+- Deterministic generation via optional random seed input
+- Rich styling controls for cell outlines, fills, markers, and background colors
+- Animated breadth-first search solver with smooth spline rendering
+- Responsive layout with debounced UI updates and device-pixel-aware canvas drawing
+
+## Getting Started
+
+1. Open `index.html` in any modern browser.
+2. Tune the controls in the left panel and click **Generate New Maze** to rebuild the maze.
+3. Optionally enter a seed value to reproduce a maze deterministically.
+4. Click **Solve Maze** to animate the path from the automatically selected start/end points.
+
+No build step is required—the project is entirely static.
+
+## Project Structure
+
+```
+index.html        # Application markup and control layout
+styles/main.css   # Visual styling for the page and controls
+scripts/main.js   # Maze generation, solving, and drawing logic
+```
+
+## Attribution
+
+Voronoi diagram computations are powered by [D3.js](https://d3js.org/).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Voronoi Tessellation Maze</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="styles/main.css" />
+</head>
+<body>
+    <div class="container">
+        <h1>Voronoi Tessellation Maze</h1>
+        <p class="description">A maze generated from a Voronoi diagram, forming a perfect tiling of irregular polygons.</p>
+
+        <fieldset class="controls" id="controls">
+            <div class="section-title">Maze Structure</div>
+
+            <div class="control-group">
+                <label for="cellCount">Number of Cells:</label>
+                <input type="range" id="cellCount" min="30" max="300" value="100" step="10" />
+                <span class="value" id="cellCountValue">100</span>
+            </div>
+
+            <div class="control-group">
+                <label for="canvasSize">Canvas Size (px):</label>
+                <input type="range" id="canvasSize" min="400" max="1000" value="800" step="50" />
+                <span class="value" id="canvasSizeValue">800</span>
+            </div>
+
+            <div class="control-group">
+                <label for="relaxation">Relaxation Iterations:</label>
+                <input type="range" id="relaxation" min="0" max="5" value="2" step="1" />
+                <span class="value" id="relaxationValue">2</span>
+            </div>
+
+            <div class="control-group">
+                <label for="passageWidth">Passage Width (%):</label>
+                <input type="range" id="passageWidth" min="10" max="90" value="50" step="5" />
+                <span class="value" id="passageWidthValue">50</span>
+            </div>
+
+            <div class="control-group">
+                <label for="seed">Random Seed:</label>
+                <input type="text" id="seed" placeholder="Leave blank for random" />
+                <span class="value seed-hint">deterministic</span>
+            </div>
+
+            <div class="section-title" style="margin-top: 20px;">Visual Appearance</div>
+
+            <div class="control-group">
+                <label for="cellStroke">Cell Outline (px):</label>
+                <input type="range" id="cellStroke" min="0.5" max="5" value="2" step="0.5" />
+                <span class="value" id="cellStrokeValue">2</span>
+            </div>
+
+            <div class="control-group">
+                <label for="markerSize">Marker Size (px):</label>
+                <input type="range" id="markerSize" min="5" max="25" value="12" step="1" />
+                <span class="value" id="markerSizeValue">12</span>
+            </div>
+
+            <div class="color-controls">
+                <div class="color-control">
+                    <label>Cell Fill</label>
+                    <input type="color" id="cellFill" value="#2a2a2a" />
+                </div>
+                <div class="color-control">
+                    <label>Cell Outline</label>
+                    <input type="color" id="cellOutline" value="#555555" />
+                </div>
+                <div class="color-control">
+                    <label>Start Marker</label>
+                    <input type="color" id="startColor" value="#2ecc71" />
+                </div>
+                <div class="color-control">
+                    <label>End Marker</label>
+                    <input type="color" id="endColor" value="#e74c3c" />
+                </div>
+                <div class="color-control">
+                    <label>Solution Path</label>
+                    <input type="color" id="solutionColor" value="#f1c40f" />
+                </div>
+                <div class="color-control">
+                    <label>Background</label>
+                    <input type="color" id="bgColor" value="#0a0a0a" />
+                </div>
+            </div>
+
+            <div class="section-title" style="margin-top: 20px;">Solution Animation</div>
+
+            <div class="control-group">
+                <label for="animationSpeed">Animation Delay (ms):</label>
+                <input type="range" id="animationSpeed" min="1" max="200" value="50" step="5" />
+                <span class="value" id="animationSpeedValue">50</span>
+            </div>
+
+            <div class="control-group">
+                <label for="pathThickness">Path Thickness (px):</label>
+                <input type="range" id="pathThickness" min="2" max="15" value="5" step="0.5" />
+                <span class="value" id="pathThicknessValue">5</span>
+            </div>
+
+            <div class="button-group">
+                <button id="generateBtn">Generate New Maze</button>
+                <button class="solve" id="solveBtn">Solve Maze</button>
+                <button class="clear" id="clearBtn">Clear Solution</button>
+            </div>
+        </fieldset>
+
+        <div id="canvasContainer">
+            <canvas id="mazeCanvas"></canvas>
+            <div id="overlay" class="overlay"></div>
+        </div>
+    </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js" integrity="sha512-pm8X5pQWcEhnkTGc3KlZvX2UmQ4PJ6oyb5acDytxqolwQDLENUXvxcZex7dqXZnpaZVwFpqiLtrJZ6XFojdrJQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script type="module" src="scripts/main.js"></script>
+</body>
+</html>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,0 +1,521 @@
+const canvas = document.getElementById('mazeCanvas');
+const ctx = canvas.getContext('2d');
+const controls = document.getElementById('controls');
+const overlay = document.getElementById('overlay');
+const generateBtn = document.getElementById('generateBtn');
+const solveBtn = document.getElementById('solveBtn');
+const clearBtn = document.getElementById('clearBtn');
+
+const structuralParams = ['cellCount', 'canvasSize', 'relaxation'];
+const visualParams = ['passageWidth', 'cellStroke', 'markerSize', 'pathThickness'];
+const colorParams = ['cellFill', 'cellOutline', 'startColor', 'endColor', 'solutionColor', 'bgColor'];
+const animationParams = ['animationSpeed'];
+
+const EDGE_PRECISION = 3;
+
+let delaunay = null;
+let voronoi = null;
+let sites = [];
+let cells = [];
+let passages = new Set();
+let solutionPath = [];
+let animationFrameId = null;
+let lastFrameTime = 0;
+let isSolving = false;
+let startCell = null;
+let endCell = null;
+let rng = Math.random;
+
+class Cell {
+    constructor(id, site, polygon) {
+        this.id = id;
+        this.site = site;
+        this.polygon = polygon;
+        this.neighbors = new Map();
+    }
+}
+
+function debounce(func, delay) {
+    let timeout;
+    return (...args) => {
+        clearTimeout(timeout);
+        timeout = setTimeout(() => func(...args), delay);
+    };
+}
+
+function showOverlay(message) {
+    overlay.textContent = message;
+    overlay.classList.add('visible');
+}
+
+function hideOverlay() {
+    overlay.classList.remove('visible');
+}
+
+function quantizePoint(point) {
+    return `${point[0].toFixed(EDGE_PRECISION)},${point[1].toFixed(EDGE_PRECISION)}`;
+}
+
+function setCanvasSize(size) {
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = size * dpr;
+    canvas.height = size * dpr;
+    canvas.style.width = `${size}px`;
+    canvas.style.height = `${size}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+}
+
+function reseedRandom() {
+    const seedInput = document.getElementById('seed').value.trim();
+    if (!seedInput) {
+        rng = Math.random;
+        return;
+    }
+
+    let seed = 0;
+    for (let i = 0; i < seedInput.length; i += 1) {
+        seed = (seed * 31 + seedInput.charCodeAt(i)) >>> 0;
+    }
+
+    if (seed === 0) {
+        seed = Date.now() >>> 0;
+    }
+
+    rng = (() => {
+        let state = seed >>> 0;
+        return () => {
+            state = (1664525 * state + 1013904223) >>> 0;
+            return state / 4294967296;
+        };
+    })();
+}
+
+function randomFloat(max) {
+    return rng() * max;
+}
+
+function generateVoronoiTessellation() {
+    const size = parseInt(document.getElementById('canvasSize').value, 10);
+    const cellCount = parseInt(document.getElementById('cellCount').value, 10);
+    const relaxIterations = parseInt(document.getElementById('relaxation').value, 10);
+
+    setCanvasSize(size);
+
+    sites = Array.from({ length: cellCount }, () => [randomFloat(size), randomFloat(size)]);
+
+    for (let iter = 0; iter < relaxIterations; iter += 1) {
+        const tempDelaunay = d3.Delaunay.from(sites);
+        const tempVoronoi = tempDelaunay.voronoi([0, 0, size, size]);
+        sites = sites.map((site, i) => {
+            const polygon = tempVoronoi.cellPolygon(i);
+            return polygon ? d3.polygonCentroid(polygon) : site;
+        });
+    }
+
+    delaunay = d3.Delaunay.from(sites);
+    voronoi = delaunay.voronoi([0, 0, size, size]);
+
+    cells = sites
+        .map((site, i) => {
+            const polygon = voronoi.cellPolygon(i);
+            return polygon ? new Cell(i, site, polygon) : null;
+        })
+        .filter(Boolean);
+
+    buildNeighborGraph();
+}
+
+function buildNeighborGraph() {
+    const cellMap = new Map(cells.map((c) => [c.id, c]));
+
+    for (const cell of cells) {
+        const neighborIds = delaunay.neighbors(cell.id);
+        for (const neighborId of neighborIds) {
+            const neighborCell = cellMap.get(neighborId);
+            if (!neighborCell || cell.neighbors.has(neighborId)) continue;
+            const edge = getSharedEdge(cell, neighborCell);
+            if (edge) {
+                cell.neighbors.set(neighborId, edge);
+                neighborCell.neighbors.set(cell.id, edge);
+            }
+        }
+    }
+}
+
+function getSharedEdge(cell1, cell2) {
+    const points2Map = new Map();
+    for (const point of cell2.polygon) {
+        points2Map.set(quantizePoint(point), point);
+    }
+
+    const shared = [];
+    for (const point of cell1.polygon) {
+        const key = quantizePoint(point);
+        if (points2Map.has(key)) {
+            shared.push([point[0], point[1]]);
+        }
+    }
+
+    if (shared.length < 2) return null;
+
+    // sort to ensure consistent ordering for downstream calculations
+    shared.sort((a, b) => (a[0] - b[0] || a[1] - b[1]));
+    return [shared[0], shared[shared.length - 1]];
+}
+
+function generateMazeKruskal() {
+    passages.clear();
+
+    const edges = [];
+    for (const cell of cells) {
+        for (const neighborId of cell.neighbors.keys()) {
+            if (cell.id < neighborId) {
+                edges.push({ cell1: cell.id, cell2: neighborId, weight: rng() });
+            }
+        }
+    }
+
+    edges.sort((a, b) => a.weight - b.weight);
+
+    const parent = new Map(cells.map((cell) => [cell.id, cell.id]));
+
+    const find = (i) => {
+        if (parent.get(i) === i) return i;
+        const root = find(parent.get(i));
+        parent.set(i, root);
+        return root;
+    };
+
+    const union = (i, j) => {
+        const rootI = find(i);
+        const rootJ = find(j);
+        if (rootI === rootJ) return false;
+        parent.set(rootI, rootJ);
+        return true;
+    };
+
+    for (const edge of edges) {
+        if (union(edge.cell1, edge.cell2)) {
+            passages.add(`${Math.min(edge.cell1, edge.cell2)}-${Math.max(edge.cell1, edge.cell2)}`);
+        }
+    }
+
+    determineStartEndCells();
+}
+
+function determineStartEndCells() {
+    let maxDistance = -Infinity;
+    let pair = [cells[0], cells[0]];
+
+    for (let i = 0; i < cells.length; i += 1) {
+        for (let j = i + 1; j < cells.length; j += 1) {
+            const dx = cells[i].site[0] - cells[j].site[0];
+            const dy = cells[i].site[1] - cells[j].site[1];
+            const distance = dx * dx + dy * dy;
+            if (distance > maxDistance) {
+                maxDistance = distance;
+                pair = [cells[i], cells[j]];
+            }
+        }
+    }
+
+    [startCell, endCell] = pair;
+}
+
+function getDrawSettings() {
+    return {
+        bgColor: document.getElementById('bgColor').value,
+        cellFill: document.getElementById('cellFill').value,
+        cellOutline: document.getElementById('cellOutline').value,
+        startColor: document.getElementById('startColor').value,
+        endColor: document.getElementById('endColor').value,
+        solutionColor: document.getElementById('solutionColor').value,
+        cellStroke: parseFloat(document.getElementById('cellStroke').value),
+        markerSize: parseFloat(document.getElementById('markerSize').value),
+        passageWidthRatio: parseFloat(document.getElementById('passageWidth').value) / 100,
+        pathThickness: parseFloat(document.getElementById('pathThickness').value)
+    };
+}
+
+function drawMaze(pathProgress = -1) {
+    const settings = getDrawSettings();
+    ctx.save();
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = settings.bgColor;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.lineJoin = 'round';
+    ctx.lineCap = 'round';
+
+    for (const cell of cells) {
+        ctx.fillStyle = settings.cellFill;
+        ctx.strokeStyle = settings.cellOutline;
+        ctx.lineWidth = settings.cellStroke;
+
+        ctx.beginPath();
+        const [firstX, firstY] = cell.polygon[0];
+        ctx.moveTo(firstX, firstY);
+        for (let i = 1; i < cell.polygon.length; i += 1) {
+            ctx.lineTo(cell.polygon[i][0], cell.polygon[i][1]);
+        }
+        ctx.closePath();
+        ctx.fill();
+        ctx.stroke();
+    }
+
+    ctx.strokeStyle = settings.cellFill;
+    ctx.lineWidth = Math.max(settings.cellStroke + 1, settings.cellStroke / settings.passageWidthRatio);
+
+    for (const passageKey of passages) {
+        const [id1, id2] = passageKey.split('-').map(Number);
+        const cell1 = cells.find((c) => c.id === id1);
+        const edge = cell1?.neighbors.get(id2);
+        if (!edge) continue;
+
+        const [p1, p2] = edge;
+        const dx = p2[0] - p1[0];
+        const dy = p2[1] - p1[1];
+        const gap = (1 - settings.passageWidthRatio) / 2;
+
+        ctx.beginPath();
+        ctx.moveTo(p1[0] + dx * gap, p1[1] + dy * gap);
+        ctx.lineTo(p2[0] - dx * gap, p2[1] - dy * gap);
+        ctx.stroke();
+    }
+
+    if (pathProgress >= 0 && solutionPath.length > 1) {
+        drawSolutionPath(pathProgress, settings);
+    }
+
+    drawMarkers(settings);
+    ctx.restore();
+}
+
+function buildSolutionSplinePoints() {
+    const points = [solutionPath[0].site];
+    for (let i = 1; i < solutionPath.length; i += 1) {
+        const prev = solutionPath[i - 1];
+        const curr = solutionPath[i];
+        const edge = prev.neighbors.get(curr.id);
+        if (edge) {
+            const [p1, p2] = edge;
+            points.push([(p1[0] + p2[0]) / 2, (p1[1] + p2[1]) / 2]);
+        }
+        points.push(curr.site);
+    }
+    return points;
+}
+
+function drawSolutionPath(pathProgress, settings) {
+    const pathPoints = buildSolutionSplinePoints();
+    const maxIndex = pathPoints.length - 1;
+    const currentIndex = Math.min(Math.floor(pathProgress) * 2, maxIndex);
+
+    ctx.save();
+    ctx.strokeStyle = settings.solutionColor;
+    ctx.lineWidth = settings.pathThickness;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+
+    ctx.beginPath();
+    ctx.moveTo(pathPoints[0][0], pathPoints[0][1]);
+    for (let i = 0; i < currentIndex; i += 1) {
+        const p1 = pathPoints[i];
+        const p2 = pathPoints[Math.min(i + 1, maxIndex)];
+        const midX = (p1[0] + p2[0]) / 2;
+        const midY = (p1[1] + p2[1]) / 2;
+        ctx.quadraticCurveTo(p1[0], p1[1], midX, midY);
+    }
+    ctx.lineTo(pathPoints[currentIndex][0], pathPoints[currentIndex][1]);
+    ctx.stroke();
+
+    const [lastX, lastY] = pathPoints[currentIndex];
+    ctx.fillStyle = settings.solutionColor;
+    ctx.beginPath();
+    ctx.arc(lastX, lastY, settings.pathThickness * 0.8, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+}
+
+function drawMarkers(settings) {
+    if (!startCell || !endCell) return;
+
+    ctx.save();
+    ctx.fillStyle = settings.startColor;
+    ctx.beginPath();
+    ctx.arc(startCell.site[0], startCell.site[1], settings.markerSize, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = '#fff';
+    ctx.lineWidth = 2;
+    ctx.stroke();
+
+    ctx.fillStyle = settings.endColor;
+    ctx.beginPath();
+    ctx.arc(endCell.site[0], endCell.site[1], settings.markerSize, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+
+    ctx.fillStyle = '#fff';
+    ctx.font = 'bold 14px Inter';
+    ctx.textAlign = 'center';
+    ctx.shadowColor = 'rgba(0,0,0,0.9)';
+    ctx.shadowBlur = 6;
+    ctx.fillText('START', startCell.site[0], startCell.site[1] - settings.markerSize - 8);
+    ctx.fillText('END', endCell.site[0], endCell.site[1] + settings.markerSize + 18);
+    ctx.restore();
+}
+
+function findPath() {
+    if (!startCell || !endCell) return [];
+
+    const queue = [[startCell]];
+    const visited = new Set([startCell.id]);
+    const cellMap = new Map(cells.map((c) => [c.id, c]));
+
+    while (queue.length > 0) {
+        const path = queue.shift();
+        const current = path[path.length - 1];
+
+        if (current.id === endCell.id) return path;
+
+        for (const neighborId of current.neighbors.keys()) {
+            const passageKey = `${Math.min(current.id, neighborId)}-${Math.max(current.id, neighborId)}`;
+            if (!passages.has(passageKey) || visited.has(neighborId)) continue;
+            visited.add(neighborId);
+            queue.push([...path, cellMap.get(neighborId)]);
+        }
+    }
+
+    return [];
+}
+
+function animateSolution() {
+    let currentIdx = 0;
+
+    const step = (timestamp) => {
+        const speed = parseInt(document.getElementById('animationSpeed').value, 10);
+        if (!lastFrameTime) lastFrameTime = timestamp;
+        const elapsed = timestamp - lastFrameTime;
+
+        if (elapsed > speed) {
+            lastFrameTime = timestamp;
+            if (currentIdx <= solutionPath.length) {
+                drawMaze(currentIdx);
+                currentIdx += 1;
+            } else {
+                finishSolving();
+                return;
+            }
+        }
+
+        animationFrameId = requestAnimationFrame(step);
+    };
+
+    animationFrameId = requestAnimationFrame(step);
+}
+
+function finishSolving() {
+    isSolving = false;
+    controls.disabled = false;
+    cancelAnimationFrame(animationFrameId);
+    animationFrameId = null;
+    lastFrameTime = 0;
+    drawMaze(solutionPath.length);
+}
+
+function solveMaze() {
+    if (isSolving) return;
+
+    clearSolution(true);
+    isSolving = true;
+    controls.disabled = true;
+
+    solutionPath = findPath();
+
+    if (solutionPath.length === 0) {
+        showOverlay('No solution found!');
+        setTimeout(hideOverlay, 2000);
+        isSolving = false;
+        controls.disabled = false;
+        return;
+    }
+
+    animateSolution();
+}
+
+function clearSolution(solving = false) {
+    if (animationFrameId) {
+        cancelAnimationFrame(animationFrameId);
+        animationFrameId = null;
+    }
+    lastFrameTime = 0;
+    solutionPath = [];
+    isSolving = false;
+    controls.disabled = false;
+    if (!solving) {
+        drawMaze();
+    }
+}
+
+function generateMaze() {
+    if (isSolving) {
+        clearSolution(true);
+    }
+
+    showOverlay('Generating...');
+    reseedRandom();
+    clearSolution(true);
+
+    setTimeout(() => {
+        generateVoronoiTessellation();
+        generateMazeKruskal();
+        drawMaze();
+        hideOverlay();
+    }, 10);
+}
+
+function setupControls() {
+    const debouncedGenerate = debounce(generateMaze, 300);
+
+    const sliderParams = [...structuralParams, ...visualParams, ...animationParams];
+    sliderParams.forEach((param) => {
+        const input = document.getElementById(param);
+        const valueDisplay = document.getElementById(`${param}Value`);
+        if (valueDisplay) {
+            input.addEventListener('input', () => {
+                valueDisplay.textContent = input.value;
+                if (visualParams.includes(param)) {
+                    drawMaze(isSolving ? solutionPath.length : -1);
+                }
+            });
+        }
+
+        if (structuralParams.includes(param)) {
+            input.addEventListener('change', debouncedGenerate);
+        }
+    });
+
+    colorParams.forEach((id) => {
+        const input = document.getElementById(id);
+        input.addEventListener('input', () => {
+            drawMaze(isSolving ? solutionPath.length : -1);
+        });
+    });
+
+    document.getElementById('seed').addEventListener('change', generateMaze);
+
+    generateBtn.addEventListener('click', generateMaze);
+    solveBtn.addEventListener('click', solveMaze);
+    clearBtn.addEventListener('click', () => clearSolution());
+}
+
+window.addEventListener(
+    'resize',
+    debounce(() => {
+        if (!cells.length) return;
+        drawMaze(isSolving ? solutionPath.length : -1);
+    }, 200)
+);
+
+setupControls();
+generateMaze();

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,282 @@
+:root {
+    --bg-dark: #121212;
+    --bg-med: #1e1e1e;
+    --bg-light: #2a2a2a;
+    --text-light: #e0e0e0;
+    --text-med: #aaaaaa;
+    --accent-green: #2ecc71;
+    --accent-green-dark: #27ae60;
+    --accent-blue: #3498db;
+    --accent-blue-dark: #2980b9;
+    --accent-orange: #e67e22;
+    --accent-orange-dark: #d35400;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background: var(--bg-dark);
+    color: var(--text-light);
+    font-family: 'Inter', sans-serif;
+    min-height: 100vh;
+}
+
+.container {
+    max-width: 1200px;
+    width: 100%;
+}
+
+#canvasContainer {
+    position: relative;
+    margin-top: 20px;
+}
+
+canvas {
+    border: 2px solid var(--bg-light);
+    background: #0a0a0a;
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.5);
+    display: block;
+    border-radius: 8px;
+    width: 100%;
+    height: auto;
+}
+
+h1 {
+    margin: 0 0 10px 0;
+    text-align: center;
+    font-weight: 700;
+    color: var(--accent-green);
+}
+
+.description {
+    text-align:center;
+    color: var(--text-med);
+    margin-bottom: 20px;
+}
+
+.controls {
+    background: var(--bg-med);
+    padding: 20px;
+    border-radius: 12px;
+    margin-bottom: 20px;
+    border: 1px solid #333;
+}
+
+.controls:disabled {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.control-group {
+    margin-bottom: 15px;
+    display: grid;
+    grid-template-columns: 200px 1fr 80px;
+    gap: 15px;
+    align-items: center;
+}
+
+@media (max-width: 768px) {
+    .control-group {
+        grid-template-columns: 1fr;
+        gap: 8px;
+    }
+
+    .control-group label {
+        text-align: left;
+    }
+
+    .control-group .value {
+        text-align: left;
+        grid-row: 1;
+        grid-column: 2;
+        justify-self: end;
+    }
+}
+
+.control-group label {
+    font-weight: 600;
+    color: var(--text-light);
+}
+
+input[type="range"] {
+    -webkit-appearance: none;
+    width: 100%;
+    height: 8px;
+    background: var(--bg-light);
+    border-radius: 5px;
+    outline: none;
+    padding: 0;
+    margin: 0;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 20px;
+    height: 20px;
+    background: var(--accent-green);
+    cursor: pointer;
+    border-radius: 50%;
+    border: 2px solid var(--bg-med);
+}
+
+input[type="range"]::-moz-range-thumb {
+    width: 20px;
+    height: 20px;
+    background: var(--accent-green);
+    cursor: pointer;
+    border-radius: 50%;
+    border: 2px solid var(--bg-med);
+}
+
+.control-group .value {
+    text-align: right;
+    color: var(--accent-green);
+    font-weight: bold;
+}
+
+.seed-hint {
+    font-weight: 400;
+    color: var(--text-med);
+}
+
+.button-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: center;
+    margin-top: 20px;
+}
+
+button {
+    padding: 12px 24px;
+    font-size: 16px;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.3s, transform 0.1s;
+    font-weight: bold;
+    background: var(--accent-green);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+}
+
+button:hover {
+    background: var(--accent-green-dark);
+    transform: translateY(-2px);
+}
+
+button:active {
+    transform: translateY(0);
+}
+
+button.solve {
+    background: var(--accent-blue);
+}
+
+button.solve:hover {
+    background: var(--accent-blue-dark);
+}
+
+button.clear {
+    background: var(--accent-orange);
+}
+
+button.clear:hover {
+    background: var(--accent-orange-dark);
+}
+
+button:disabled {
+    background: #555;
+    cursor: not-allowed;
+    transform: none;
+    opacity: 0.7;
+}
+
+.color-controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 15px;
+    margin-top: 15px;
+    padding-top: 15px;
+    border-top: 1px solid #444;
+}
+
+.color-control {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.color-control label {
+    font-size: 12px;
+    color: var(--text-med);
+}
+
+.color-control input[type="color"] {
+    width: 100%;
+    height: 40px;
+    border: 1px solid #444;
+    border-radius: 4px;
+    cursor: pointer;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-color: transparent;
+    padding: 0;
+}
+
+.color-control input[type="color"]::-webkit-color-swatch-wrapper {
+    padding: 0;
+}
+
+.color-control input[type="color"]::-webkit-color-swatch {
+    border: none;
+    border-radius: 4px;
+}
+
+.color-control input[type="color"]::-moz-color-swatch {
+    border: none;
+    border-radius: 4px;
+}
+
+.section-title {
+    font-size: 18px;
+    color: var(--accent-green);
+    margin-bottom: 15px;
+    padding-bottom: 5px;
+    border-bottom: 2px solid var(--accent-green);
+    font-weight: 600;
+}
+
+.overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.7);
+    color: white;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 1.5em;
+    border-radius: 8px;
+    text-align: center;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s;
+    z-index: 10;
+}
+
+.overlay.visible {
+    opacity: 1;
+    pointer-events: all;
+}


### PR DESCRIPTION
## Summary
- build a standalone Voronoi maze generator page with responsive controls and overlay messaging
- add seeded randomness, device-pixel-aware rendering, and smoother solution animation
- document the project structure and usage in the README

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e10d98b12c83219e645e76a549fd47