### PR TITLE
Use inline SVG favicon to avoid binary file issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="styles/main.css" />
+    <link
+        rel="icon"
+        type="image/svg+xml"
+        href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%2064%2064%27%3E%3Crect%20width%3D%2764%27%20height%3D%2764%27%20rx%3D%2712%27%20fill%3D%27%230a0a0a%27/%3E%3Cpath%20d%3D%27M16%2018%20L32%2048%20L48%2018%27%20stroke%3D%27%23f1c40f%27%20stroke-width%3D%278%27%20fill%3D%27none%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27/%3E%3C/svg%3E"
+    />
 </head>
 <body>
     <div class="container">
@@ -115,7 +120,12 @@
         </div>
     </div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js" integrity="sha512-pm8X5pQWcEhnkTGc3KlZvX2UmQ4PJ6oyb5acDytxqolwQDLENUXvxcZex7dqXZnpaZVwFpqiLtrJZ6XFojdrJQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script
+        src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"
+        integrity="sha512-M7nHCiNUOwFt6Us3r8alutZLm9qMt4s9951uo8jqO4UwJ1hziseL6O3ndFyigx6+LREfZqnhHxYjKRJ8ZQ69DQ=="
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"
+    ></script>
     <script type="module" src="scripts/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update the D3 CDN script tag with the correct integrity hash so the library loads successfully
- replace the favicon asset with an inline SVG data URL so the page has an icon without relying on a binary file

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e13d4f8c3c832185febaf24a9c15b1