### PR TITLE
Add maze export button to download PNG snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A modern single-page Voronoi maze generator that uses D3's Delaunay/Voronoi util
 - Rich styling controls for cell outlines, fills, markers, and background colors
 - Animated breadth-first search solver with smooth spline rendering
 - Responsive layout with debounced UI updates and device-pixel-aware canvas drawing
+- One-click PNG export of the current maze view
 
 ## Installation
 

--- a/index.html
+++ b/index.html
@@ -110,6 +110,7 @@
             <div class="button-group">
                 <button id="generateBtn">Generate New Maze</button>
                 <button class="solve" id="solveBtn">Solve Maze</button>
+                <button class="export" id="exportBtn">Download Maze</button>
                 <button class="clear" id="clearBtn">Clear Solution</button>
             </div>
         </fieldset>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -5,6 +5,7 @@ const overlay = document.getElementById('overlay');
 const generateBtn = document.getElementById('generateBtn');
 const solveBtn = document.getElementById('solveBtn');
 const clearBtn = document.getElementById('clearBtn');
+const exportBtn = document.getElementById('exportBtn');
 
 const structuralParams = ['cellCount', 'canvasSize', 'relaxation'];
 const visualParams = ['passageWidth', 'cellStroke', 'markerSize', 'pathThickness'];
@@ -50,6 +51,42 @@ function showOverlay(message) {
 
 function hideOverlay() {
     overlay.classList.remove('visible');
+}
+
+function downloadMazeImage() {
+    if (!cells.length) {
+        showOverlay('Generate a maze first!');
+        setTimeout(hideOverlay, 1800);
+        return;
+    }
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const filename = `voronoi-maze-${timestamp}.png`;
+
+    const triggerDownload = (url, revoke = false) => {
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        if (revoke) {
+            URL.revokeObjectURL(url);
+        }
+    };
+
+    if (canvas.toBlob) {
+        canvas.toBlob((blob) => {
+            if (blob) {
+                const url = URL.createObjectURL(blob);
+                triggerDownload(url, true);
+            } else {
+                triggerDownload(canvas.toDataURL('image/png'));
+            }
+        }, 'image/png');
+    } else {
+        triggerDownload(canvas.toDataURL('image/png'));
+    }
 }
 
 function quantizePoint(point) {
@@ -507,6 +544,7 @@ function setupControls() {
     generateBtn.addEventListener('click', generateMaze);
     solveBtn.addEventListener('click', solveMaze);
     clearBtn.addEventListener('click', () => clearSolution());
+    exportBtn.addEventListener('click', downloadMazeImage);
 }
 
 window.addEventListener(

--- a/styles/main.css
+++ b/styles/main.css
@@ -10,6 +10,8 @@
     --accent-blue-dark: #2980b9;
     --accent-orange: #e67e22;
     --accent-orange-dark: #d35400;
+    --accent-purple: #9b59b6;
+    --accent-purple-dark: #8e44ad;
 }
 
 * {
@@ -183,6 +185,14 @@ button.solve {
 
 button.solve:hover {
     background: var(--accent-blue-dark);
+}
+
+button.export {
+    background: var(--accent-purple);
+}
+
+button.export:hover {
+    background: var(--accent-purple-dark);
 }
 
 button.clear {


### PR DESCRIPTION
## Summary
- add a Download Maze button to the controls for exporting the canvas as a PNG image
- implement client-side download logic with toBlob/dataURL fallbacks and a guard when no maze is available
- style the new export action with distinct accent colors and document the capability in the README

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e46e1da1448321b1ae0305109e6c41